### PR TITLE
Summary:  clean up incorrect, brittle, unnecessary, or out-of-date code

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-_build/
+_build*/
 .deps/
 .libs/
 *.lo

--- a/ImCreate_test.c
+++ b/ImCreate_test.c
@@ -1,143 +1,91 @@
 /*
  * Example code to write image in shared memory
- * 
+ *
  * compile with:
- * gcc ImCreate_test.c ImageStreamIO.c -lm -lpthread 
- * 
+ * gcc ImCreate_test.c ImageStreamIO.c -lm -lpthread
+ *
  * Required files in compilation directory :
  * ImCreate_test.c   : source code (this file)
  * ImageStreamIO.c   : ImageStreamIO source code
  * ImageStreamIO.h   : ImageCreate function prototypes
  * ImageStruct.h     : Image structure definition
- * 
+ *
  * EXECUTION:
- * ./a.out  
+ * ./a.out
  * (no argument)
- * 
+ *
  * Creates an image imtest00 in shared memory
- * Updates the image every ~ 10ms, forever...
- * A square is rotating around the center of the image
- * 
+ * Updates the image every ~ 1ms, forever...
+ * A disk is rotating around the center of the image
+ *
  */
 
-
-
-
-#include <stdio.h>
-#include <stdlib.h>
 #include <math.h>
-#include "ImageStruct.h"
+#include <stdio.h>
+//#include <stdlib.h>
 #include "ImageStreamIO.h"
-
-
-
 
 int main()
 {
-	IMAGE *imarray;    // pointer to array of images
-	int NBIMAGES = 1;  // can hold 1 image
-	long naxis;        // number of axis
-	uint8_t atype;     // data type
-	uint32_t *imsize;  // image size 
-	int shared;        // 1 if image in shared memory
-	int NBkw;          // number of keywords supported
+    IMAGE imarray[1];              // pointer to array of images
+    uint32_t imsize[2] = { 512, 512 }; // image size is 512 x 512
+    long naxis = sizeof(imsize) / (sizeof *imsize);  // # of axes
 
+    // Data type; see file ImageStruct.h for list of supported types
+    uint8_t atype = _DATATYPE_FLOAT;
 
+    int shared = 1;                // 1 if image in shared mem
+    int NBkw = 10;                 // number of keywords allowed
 
-	
+    // create an image in shared memory
+    ImageStreamIO_createIm(imarray, "imtest00", naxis, imsize, atype, shared, NBkw, 1);
 
-	// allocate memory for array of images
-	imarray = (IMAGE*) malloc(sizeof(IMAGE)*NBIMAGES);
+    long ii, jj;              // Image column and row indices
+    float x0, y0, xc, yc;     // Image center; disk center
+    long dtus = 1000;         // Wait 1ms = 1000 microseconds
+    float dangle = 1/64.0;    // Angle step size
+    float angle = 0.0;        // Angle of disc center, CW from right
+    float r = 100.0;          // Radius of disk center from image center
 
-	
-	// image will be 2D
-	naxis = 2;
-	
-	// image size will be 512 x 512
-	imsize = (uint32_t *) malloc(sizeof(uint32_t)*naxis);
-	imsize[0] = 512;
-	imsize[1] = 512;
-	
-	// image will be float type
-	// see file ImageStruct.h for list of supported types
-	atype = _DATATYPE_FLOAT;
-	
-	// image will be in shared memory
-	shared = 1;
-	
-	// allocate space for 10 keywords
-	NBkw = 10;
+    x0 = 0.5*imarray->md->size[0];           // Calculate enter of image
+    y0 = 0.5*imarray->md->size[1];
 
+    // Writes a disk in image
+    // - Location of disk center rotates around image center
+    while (1)
+    {
+        // Calculate disk center location based on angle,
+        // then increment angle for the next loop pass
+        xc = x0 + r*cos(angle);
+        yc = y0 + r*sin(angle);
+        angle += dangle;
+        if(angle > 2.0*M_PI) { angle -= 2.0 * M_PI; }
 
-	
-	// create an image in shared memory
-	ImageStreamIO_createIm(&imarray[0], "imtest00", naxis, imsize, atype, shared, NBkw);
+        imarray->md->write = 1;         // Poor-man's mutex when writing
 
+        // ->array is union; ->array.F is float pointer to image
+        float* dotF = imarray->array.F;
+        for(jj=0; jj<imarray->md->size[1]; jj++)            // loop rows
+        {
+            float dy = jj-yc;
+            float dy2 = dy*dy;
+            for(ii=0; ii<imarray->md->size[0]; ii++)     // loop columns
+            {
+                float dx = ii-xc;
+                // Brightness is highest at the center
+                // of the disk and fades radially
+                *(dotF++) = cos(0.003*dx)*cos(0.003*dy)*exp(-1.0e-4*(dx*dx+dy2));
 
+            }
+        }
+        // Post all semaphores (index = -1)
+        ImageStreamIO_sempost(imarray, -1);
 
-	float angle; 
-	float r;
-	float r1;
-	long ii, jj;
-	float x, y, x0, y0, xc, yc;
-	// float squarerad=20;
-	long dtus = 1000; // update every 1ms
-	float dangle = 0.02;
-	
-	int s;
-	int semval;
+        imarray->md->write = 0; // Done writing; release mutex
+        imarray->md->cnt0++;
+        imarray->md->cnt1++;
 
-	// writes a square in image
-	// square location rotates around center
-	angle = 0.0;
-	r = 100.0;
-	x0 = 0.5*imarray[0].md[0].size[0];
-	y0 = 0.5*imarray[0].md[0].size[1];
-	while (1)
-	{
-		// disk location
-		xc = x0 + r*cos(angle);
-		yc = y0 + r*sin(angle);
-		
-		
-		imarray[0].md[0].write = 1; // set this flag to 1 when writing data
-		
-		for(ii=0; ii<imarray[0].md[0].size[0]; ii++)
-			for(jj=0; jj<imarray[0].md[0].size[1]; jj++)
-			{
-				x = 1.0*ii;
-				y = 1.0*jj;
-				float dx = x-xc;
-				float dy = y-yc;
-				
-				imarray[0].array.F[jj*imarray[0].md[0].size[0]+ii] = cos(0.03*dx)*cos(0.03*dy)*exp(-1.0e-4*(dx*dx+dy*dy));
-				
-				//if( (x-xc<squarerad) && (x-xc>-squarerad) && (y-yc<squarerad) && (y-yc>-squarerad))
-				//	imarray[0].array.F[jj*imarray[0].md[0].size[0]+ii] = 1.0;
-				//else
-				//	imarray[0].array.F[jj*imarray[0].md[0].size[0]+ii] = 0.0;
-			}
-		
-		// POST ALL SEMAPHORES
-		ImageStreamIO_sempost(&imarray[0], -1);
-		
-		imarray[0].md[0].write = 0; // Done writing data
-		imarray[0].md[0].cnt0++;
-		imarray[0].md[0].cnt1++;
-		
-		
-		usleep(dtus);
-		angle += dangle;
-		if(angle > 2.0*3.141592)
-			angle -= 2.0*3.141592;
-		//printf("Wrote square at position xc = %16f  yc = %16f\n", xc, yc);
-		//fflush(stdout);
-	}
-	
-
-
-	free(imsize);
-	free(imarray);
-	
-	return 0;
+        usleep(dtus);           // Wait 1ms
+    }
+    return 0;
 }

--- a/ImageStreamIO.c
+++ b/ImageStreamIO.c
@@ -8,7 +8,9 @@
  *
  */
 
+#ifndef _GNU_SOURCE
 #define _GNU_SOURCE
+#endif//_GNU_SOURCE
 
 #include <math.h>
 #include <pthread.h>
@@ -88,6 +90,7 @@ errno_t (*internal_printError)(const char *, const char *, int, errno_t,
 errno_t ImageStreamIO_set_default_printError()
 {
     internal_printError = &ImageStreamIO_printERROR_;
+
     return IMAGESTREAMIO_SUCCESS;
 }
 
@@ -95,6 +98,7 @@ errno_t ImageStreamIO_set_printError(errno_t (*new_printError)(const char *,
                                      const char *, int, errno_t, char *))
 {
     internal_printError = new_printError;
+
     return IMAGESTREAMIO_SUCCESS;
 }
 
@@ -273,55 +277,37 @@ errno_t ImageStreamIO_readBufferAt(
 errno_t ImageStreamIO_shmdirname(
     char *shmdname)
 {
-    int shmdirOK = 0;
-    DIR *tmpdir;
+    DIR *tmpdir = NULL;  // Initialize to failure (NULL dir stream)
 
     // first, we try the env variable if it exists
     char *MILK_SHM_DIR = getenv("MILK_SHM_DIR");
     if (MILK_SHM_DIR != NULL)
     {
-        // printf(" [ MILK_SHM_DIR ] '%s'\n", MILK_SHM_DIR);
         snprintf(shmdname,STRINGMAXLEN_DIR_NAME, "%s", MILK_SHM_DIR);
-
         // does this direcory exist ?
         tmpdir = opendir(shmdname);
-        if (tmpdir) // directory exits
-        {
-            shmdirOK = 1;
-            closedir(tmpdir);
-        }
-        else
-        {
+        if (!tmpdir)
+        {   // Print warning about envvar if envvar has in valid dir
             printf(" [ WARNING ] '%s' does not exist\n", MILK_SHM_DIR);
         }
     }
-
     // second, we try SHAREDMEMDIR default
-    if (shmdirOK == 0)
+    if (!tmpdir)
     {
-        tmpdir = opendir(SHAREDMEMDIR);
-        if (tmpdir) // directory exits
-        {
-            snprintf(shmdname, STRINGMAXLEN_DIR_NAME, "%s", SHAREDMEMDIR);
-            shmdirOK = 1;
-            closedir(tmpdir);
-        }
+        snprintf(shmdname, STRINGMAXLEN_DIR_NAME, "%s", SHAREDMEMDIR);
+        tmpdir = opendir(shmdname);
     }
-
     // if all above fails, set to /tmp
-    if (shmdirOK == 0)
+    if (!tmpdir)
     {
-        tmpdir = opendir("/tmp");
-        if (!tmpdir)
-        {
-            exit(EXIT_FAILURE);
-        }
-        else
-        {
-            snprintf(shmdname, STRINGMAXLEN_DIR_NAME, "/tmp");
-            shmdirOK = 1;
-        }
+        snprintf(shmdname, STRINGMAXLEN_DIR_NAME, "%s", "/tmp");
+        tmpdir = opendir(shmdname);
     }
+    // Failure:  no directories were found that could be opened
+    if (!tmpdir) { exit(EXIT_FAILURE); }
+
+    // Success:  close directory stream; dirname is in shdname
+    closedir(tmpdir);
 
     return IMAGESTREAMIO_SUCCESS;
 }
@@ -331,7 +317,6 @@ errno_t ImageStreamIO_filename(
     size_t ssz,
     const char *im_name)
 {
-
     static char shmdirname[STRINGMAXLEN_DIR_NAME];
     static int initSHAREDMEMDIR = 0;
 
@@ -343,11 +328,9 @@ errno_t ImageStreamIO_filename(
 
     int rv = snprintf(file_name, ssz, "%s/%s.im.shm", shmdirname, im_name);
 
-    if ((rv > 0) && (rv < (int)ssz))
-    {
-        return IMAGESTREAMIO_SUCCESS;
-    }
-    else if (rv < 0)
+    if ((rv > 0) && (rv < (int)ssz)) { return IMAGESTREAMIO_SUCCESS; }
+
+    if (rv < 0)
     {
         ImageStreamIO_printERROR(IMAGESTREAMIO_FAILURE, strerror(errno));
         return IMAGESTREAMIO_FAILURE;
@@ -355,7 +338,7 @@ errno_t ImageStreamIO_filename(
     else
     {
         ImageStreamIO_printERROR(IMAGESTREAMIO_FAILURE,
-                                 "string not large enough for file name");
+                                 (char*)"string not large enough for file name");
         return IMAGESTREAMIO_FAILURE;
     }
 }
@@ -366,37 +349,23 @@ int ImageStreamIO_typesize(
 {
     switch (datatype)
     {
-    case _DATATYPE_UINT8:
-        return SIZEOF_DATATYPE_UINT8;
-    case _DATATYPE_INT8:
-        return SIZEOF_DATATYPE_INT8;
-    case _DATATYPE_UINT16:
-        return SIZEOF_DATATYPE_UINT16;
-    case _DATATYPE_INT16:
-        return SIZEOF_DATATYPE_INT16;
-    case _DATATYPE_UINT32:
-        return SIZEOF_DATATYPE_UINT32;
-    case _DATATYPE_INT32:
-        return SIZEOF_DATATYPE_INT32;
-    case _DATATYPE_UINT64:
-        return SIZEOF_DATATYPE_UINT64;
-    case _DATATYPE_INT64:
-        return SIZEOF_DATATYPE_INT64;
-    case _DATATYPE_HALF:
-        return SIZEOF_DATATYPE_HALF;
-    case _DATATYPE_FLOAT:
-        return SIZEOF_DATATYPE_FLOAT;
-    case _DATATYPE_DOUBLE:
-        return SIZEOF_DATATYPE_DOUBLE;
-    case _DATATYPE_COMPLEX_FLOAT:
-        return SIZEOF_DATATYPE_COMPLEX_FLOAT;
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return SIZEOF_DATATYPE_COMPLEX_DOUBLE;
-
-    default:
-        ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, "invalid type code");
-        return -1; // This is an in-band error code, so can't be > 0.
+    case _DATATYPE_UINT8:         return SIZEOF_DATATYPE_UINT8;
+    case _DATATYPE_INT8:          return SIZEOF_DATATYPE_INT8;
+    case _DATATYPE_UINT16:        return SIZEOF_DATATYPE_UINT16;
+    case _DATATYPE_INT16:         return SIZEOF_DATATYPE_INT16;
+    case _DATATYPE_UINT32:        return SIZEOF_DATATYPE_UINT32;
+    case _DATATYPE_INT32:         return SIZEOF_DATATYPE_INT32;
+    case _DATATYPE_UINT64:        return SIZEOF_DATATYPE_UINT64;
+    case _DATATYPE_INT64:         return SIZEOF_DATATYPE_INT64;
+    case _DATATYPE_HALF:          return SIZEOF_DATATYPE_HALF;
+    case _DATATYPE_FLOAT:         return SIZEOF_DATATYPE_FLOAT;
+    case _DATATYPE_DOUBLE:        return SIZEOF_DATATYPE_DOUBLE;
+    case _DATATYPE_COMPLEX_FLOAT: return SIZEOF_DATATYPE_COMPLEX_FLOAT;
+    case _DATATYPE_COMPLEX_DOUBLE:return SIZEOF_DATATYPE_COMPLEX_DOUBLE;
+    default:                      break;
     }
+    ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, (char*)"invalid type code");
+    return -1; // This is an in-band error code, so can't be > 0.
 }
 
 const char *ImageStreamIO_typename(
@@ -404,36 +373,22 @@ const char *ImageStreamIO_typename(
 {
     switch (datatype)
     {
-    case _DATATYPE_UINT8:
-        return "UINT8";
-    case _DATATYPE_INT8:
-        return "INT8";
-    case _DATATYPE_UINT16:
-        return "UINT16";
-    case _DATATYPE_INT16:
-        return "INT16";
-    case _DATATYPE_UINT32:
-        return "UINT32";
-    case _DATATYPE_INT32:
-        return "INT32";
-    case _DATATYPE_UINT64:
-        return "UINT64";
-    case _DATATYPE_INT64:
-        return "INT64";
-    case _DATATYPE_HALF:
-        return "FLT16";
-    case _DATATYPE_FLOAT:
-        return "FLT32";
-    case _DATATYPE_DOUBLE:
-        return "FLT64";
-    case _DATATYPE_COMPLEX_FLOAT:
-        return "CPLX32";
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return "CPLX64";
-
-    default:
-        return "unknown";
+    case _DATATYPE_UINT8:          return "UINT8";
+    case _DATATYPE_INT8:           return "INT8";
+    case _DATATYPE_UINT16:         return "UINT16";
+    case _DATATYPE_INT16:          return "INT16";
+    case _DATATYPE_UINT32:         return "UINT32";
+    case _DATATYPE_INT32:          return "INT32";
+    case _DATATYPE_UINT64:         return "UINT64";
+    case _DATATYPE_INT64:          return "INT64";
+    case _DATATYPE_HALF:           return "FLT16";
+    case _DATATYPE_FLOAT:          return "FLT32";
+    case _DATATYPE_DOUBLE:         return "FLT64";
+    case _DATATYPE_COMPLEX_FLOAT:  return "CPLX32";
+    case _DATATYPE_COMPLEX_DOUBLE: return "CPLX64";
+    default:                       break;
     }
+    return "unknown";
 }
 
 const char *ImageStreamIO_typename_7(
@@ -441,42 +396,26 @@ const char *ImageStreamIO_typename_7(
 {
     switch (datatype)
     {
-    case _DATATYPE_UINT8:
-        return "UINT8  ";
-    case _DATATYPE_INT8:
-        return "INT8   ";
-    case _DATATYPE_UINT16:
-        return "UINT16 ";
-    case _DATATYPE_INT16:
-        return "INT16  ";
-    case _DATATYPE_UINT32:
-        return "UINT32 ";
-    case _DATATYPE_INT32:
-        return "INT32  ";
-    case _DATATYPE_UINT64:
-        return "UINT64 ";
-    case _DATATYPE_INT64:
-        return "INT64  ";
-    case _DATATYPE_HALF:
-        return "FLT16  ";
-    case _DATATYPE_FLOAT:
-        return "FLOAT  ";
-    case _DATATYPE_DOUBLE:
-        return "DOUBLE ";
-    case _DATATYPE_COMPLEX_FLOAT:
-        return "CFLOAT ";
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return "CDOUBLE";
-
-    default:
-        return "unknown";
+    case _DATATYPE_UINT8:          return "UINT8  ";
+    case _DATATYPE_INT8:           return "INT8   ";
+    case _DATATYPE_UINT16:         return "UINT16 ";
+    case _DATATYPE_INT16:          return "INT16  ";
+    case _DATATYPE_UINT32:         return "UINT32 ";
+    case _DATATYPE_INT32:          return "INT32  ";
+    case _DATATYPE_UINT64:         return "UINT64 ";
+    case _DATATYPE_INT64:          return "INT64  ";
+    case _DATATYPE_HALF:           return "FLT16  ";
+    case _DATATYPE_FLOAT:          return "FLOAT  ";
+    case _DATATYPE_DOUBLE:         return "DOUBLE ";
+    case _DATATYPE_COMPLEX_FLOAT:  return "CFLOAT ";
+    case _DATATYPE_COMPLEX_DOUBLE: return "CDOUBLE";
+    default:                       break;
     }
+    return "unknown";
 }
 
 int ImageStreamIO_checktype(uint8_t datatype, int complex_allowed)
 {
-    int complex_retval = complex_allowed ? 0 : -1;
-
     switch (datatype) {
     case _DATATYPE_UINT8:
     case _DATATYPE_INT8:
@@ -488,16 +427,15 @@ int ImageStreamIO_checktype(uint8_t datatype, int complex_allowed)
     case _DATATYPE_INT64:
     case _DATATYPE_HALF:
     case _DATATYPE_FLOAT:
-    case _DATATYPE_DOUBLE:
-        return 0;
-    case _DATATYPE_COMPLEX_FLOAT:
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return complex_retval;
+    case _DATATYPE_DOUBLE:          return 0;
 
-    default:
-        ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, "invalid type code");
-        return -1; // This is an in-band error code, so can't be > 0.
+    case _DATATYPE_COMPLEX_FLOAT:
+    case _DATATYPE_COMPLEX_DOUBLE:  return complex_allowed ? 0 : -1;
+
+    default:                        break;
     }
+    ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, (char*)"invalid type code");
+    return -1; // This is an in-band error code, so can't be > 0.
 }
 
 const char *ImageStreamIO_typename_short(
@@ -505,35 +443,22 @@ const char *ImageStreamIO_typename_short(
 {
     switch (datatype)
     {
-    case _DATATYPE_UINT8:
-        return " UI8";
-    case _DATATYPE_INT8:
-        return "  I8";
-    case _DATATYPE_UINT16:
-        return "UI16";
-    case _DATATYPE_INT16:
-        return " I16";
-    case _DATATYPE_UINT32:
-        return "UI32";
-    case _DATATYPE_INT32:
-        return " I32";
-    case _DATATYPE_UINT64:
-        return " UI64";
-    case _DATATYPE_INT64:
-        return " I64";
-    case _DATATYPE_HALF:
-        return " F16";
-    case _DATATYPE_FLOAT:
-        return " FLT";
-    case _DATATYPE_DOUBLE:
-        return " DBL";
-    case _DATATYPE_COMPLEX_FLOAT:
-        return "CFLT";
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return "CDBL";
-    default:
-        return " ???";
+    case _DATATYPE_UINT8:          return " UI8";
+    case _DATATYPE_INT8:           return "  I8";
+    case _DATATYPE_UINT16:         return "UI16";
+    case _DATATYPE_INT16:          return " I16";
+    case _DATATYPE_UINT32:         return "UI32";
+    case _DATATYPE_INT32:          return " I32";
+    case _DATATYPE_UINT64:         return "UI64";
+    case _DATATYPE_INT64:          return " I64";
+    case _DATATYPE_HALF:           return " F16";
+    case _DATATYPE_FLOAT:          return " FLT";
+    case _DATATYPE_DOUBLE:         return " DBL";
+    case _DATATYPE_COMPLEX_FLOAT:  return "CFLT";
+    case _DATATYPE_COMPLEX_DOUBLE: return "CDBL";
+    default:                       break;
     }
+    return " ???";
 }
 
 int ImageStreamIO_floattype(
@@ -541,37 +466,23 @@ int ImageStreamIO_floattype(
 {
     switch (datatype)
     {
-    case _DATATYPE_UINT8:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_INT8:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_UINT16:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_INT16:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_UINT32:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_INT32:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_UINT64:
-        return _DATATYPE_DOUBLE;
-    case _DATATYPE_INT64:
-        return _DATATYPE_DOUBLE;
-    case _DATATYPE_HALF:
-        return _DATATYPE_HALF;
-    case _DATATYPE_FLOAT:
-        return _DATATYPE_FLOAT;
-    case _DATATYPE_DOUBLE:
-        return _DATATYPE_DOUBLE;
-    case _DATATYPE_COMPLEX_FLOAT:
-        return _DATATYPE_COMPLEX_FLOAT;
-    case _DATATYPE_COMPLEX_DOUBLE:
-        return _DATATYPE_COMPLEX_DOUBLE;
-
-    default:
-        ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, "invalid type code");
-        return -1; // This is an in-band error code, so can't be > 0.
+    case _DATATYPE_UINT8:          return _DATATYPE_FLOAT;
+    case _DATATYPE_INT8:           return _DATATYPE_FLOAT;
+    case _DATATYPE_UINT16:         return _DATATYPE_FLOAT;
+    case _DATATYPE_INT16:          return _DATATYPE_FLOAT;
+    case _DATATYPE_UINT32:         return _DATATYPE_FLOAT;
+    case _DATATYPE_INT32:          return _DATATYPE_FLOAT;
+    case _DATATYPE_UINT64:         return _DATATYPE_DOUBLE;
+    case _DATATYPE_INT64:          return _DATATYPE_DOUBLE;
+    case _DATATYPE_HALF:           return _DATATYPE_HALF;
+    case _DATATYPE_FLOAT:          return _DATATYPE_FLOAT;
+    case _DATATYPE_DOUBLE:         return _DATATYPE_DOUBLE;
+    case _DATATYPE_COMPLEX_FLOAT:  return _DATATYPE_COMPLEX_FLOAT;
+    case _DATATYPE_COMPLEX_DOUBLE: return _DATATYPE_COMPLEX_DOUBLE;
+    default:                       break;
     }
+    ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, (char*)"invalid type code");
+    return -1; // This is an in-band error code, so can't be > 0.
 }
 
 int ImageStreamIO_FITSIOdatatype(uint8_t datatype)
@@ -579,32 +490,22 @@ int ImageStreamIO_FITSIOdatatype(uint8_t datatype)
     switch (datatype)
     {
 #ifdef USE_CFITSIO
-    case _DATATYPE_UINT8:
-        return TBYTE;
-    case _DATATYPE_INT8:
-        return TSBYTE;
-    case _DATATYPE_UINT16:
-        return TUSHORT;
-    case _DATATYPE_INT16:
-        return TSHORT;
-    case _DATATYPE_UINT32:
-        return TUINT;
-    case _DATATYPE_INT32:
-        return TINT;
-    case _DATATYPE_UINT64:
-        return TULONG;
-    case _DATATYPE_INT64:
-        return TLONG;
-    case _DATATYPE_FLOAT:
-        return TFLOAT;
-    case _DATATYPE_DOUBLE:
-        return TDOUBLE;
+    case _DATATYPE_UINT8:  return TBYTE;
+    case _DATATYPE_INT8:   return TSBYTE;
+    case _DATATYPE_UINT16: return TUSHORT;
+    case _DATATYPE_INT16:  return TSHORT;
+    case _DATATYPE_UINT32: return TUINT;
+    case _DATATYPE_INT32:  return TINT;
+    case _DATATYPE_UINT64: return TULONG;
+    case _DATATYPE_INT64:  return TLONG;
+    case _DATATYPE_FLOAT:  return TFLOAT;
+    case _DATATYPE_DOUBLE: return TDOUBLE;
 #endif
-    default:
-        ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG,
-                                 "bitpix not implemented for type");
-        return -1; // This is an in-band error code, must be unique from valid BITPIX values.
+    default:               break;
     }
+    ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG,
+                             (char*)"bitpix not implemented for type");
+    return -1; // This is an in-band error code, must be unique from valid BITPIX values.
 }
 
 int ImageStreamIO_FITSIObitpix(
@@ -613,32 +514,22 @@ int ImageStreamIO_FITSIObitpix(
     switch (datatype)
     {
 #ifdef USE_CFITSIO
-    case _DATATYPE_UINT8:
-        return BYTE_IMG;
-    case _DATATYPE_INT8:
-        return SBYTE_IMG;
-    case _DATATYPE_UINT16:
-        return USHORT_IMG;
-    case _DATATYPE_INT16:
-        return SHORT_IMG;
-    case _DATATYPE_UINT32:
-        return ULONG_IMG;
-    case _DATATYPE_INT32:
-        return LONG_IMG;
-    case _DATATYPE_UINT64:
-        return ULONGLONG_IMG;
-    case _DATATYPE_INT64:
-        return LONGLONG_IMG;
-    case _DATATYPE_FLOAT:
-        return FLOAT_IMG;
-    case _DATATYPE_DOUBLE:
-        return DOUBLE_IMG;
+    case _DATATYPE_UINT8:  return BYTE_IMG;
+    case _DATATYPE_INT8:   return SBYTE_IMG;
+    case _DATATYPE_UINT16: return USHORT_IMG;
+    case _DATATYPE_INT16:  return SHORT_IMG;
+    case _DATATYPE_UINT32: return ULONG_IMG;
+    case _DATATYPE_INT32:  return LONG_IMG;
+    case _DATATYPE_UINT64: return ULONGLONG_IMG;
+    case _DATATYPE_INT64:  return LONGLONG_IMG;
+    case _DATATYPE_FLOAT:  return FLOAT_IMG;
+    case _DATATYPE_DOUBLE: return DOUBLE_IMG;
 #endif
-    default:
-        ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG,
-                                 "bitpix not implemented for type");
-        return -1; // This is an in-band error code, must be unique from valid BITPIX values.
+    default:               break;
     }
+    ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG,
+                             (char*)"bitpix not implemented for type");
+    return -1; // This is an in-band error code, must be unique from valid BITPIX values.
 }
 
 
@@ -679,14 +570,16 @@ uint64_t ImageStreamIO_initialize_buffer(
     {
         if (image->md->shared == 1)
         {
-            memset(image->array.raw, '\0', image->md->nelement * size_element);
+            memset(image->array.raw, 0, image->md->nelement * size_element);
+            // memset takes an int source value
+            //memset(image->array.raw, '\0', image->md->nelement * size_element);
         }
         else
         {
             image->array.raw = calloc((size_t)image->md->nelement, size_element);
             if (image->array.raw == NULL)
             {
-                ImageStreamIO_printERROR(IMAGESTREAMIO_BADALLOC, "memory allocation failed");
+                ImageStreamIO_printERROR(IMAGESTREAMIO_BADALLOC, (char*)"memory allocation failed");
                 fprintf(stderr, "%c[%d;%dm", (char)27, 1, 31);
                 fprintf(stderr, "Image name = %s\n", image->name);
                 fprintf(stderr, "Image size = ");
@@ -718,7 +611,7 @@ uint64_t ImageStreamIO_initialize_buffer(
         }
 #else
         ImageStreamIO_printERROR(IMAGESTREAMIO_NOTIMPL,
-                                 "unsupported location, milk needs to be compiled with -DUSE_CUDA=ON"); ///\todo should this return an error?
+                                 (char*)"unsupported location, milk needs to be compiled with -DUSE_CUDA=ON"); ///\todo should this return an error?
 #endif
     }
 
@@ -792,7 +685,7 @@ errno_t ImageStreamIO_createIm_gpu(
             (naxis != 3))
     {
         ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG,
-                                 "Error calling ImageStreamIO_createIm_gpu, "
+                                 (char*)"Error calling ImageStreamIO_createIm_gpu, "
                                  "temporal circular buffer needs 3 dimensions");
         return IMAGESTREAMIO_INVALIDARG;
     }
@@ -817,7 +710,7 @@ errno_t ImageStreamIO_createIm_gpu(
         }
         else
         {
-            ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, "Error location unknown");
+            ImageStreamIO_printERROR(IMAGESTREAMIO_INVALIDARG, (char*)"Error location unknown");
             return IMAGESTREAMIO_FAILURE;
         }
 
@@ -864,7 +757,7 @@ errno_t ImageStreamIO_createIm_gpu(
         if ((stat(SM_fname, &buffer) == 0) && (location > -1))
         {
             ImageStreamIO_printERROR(IMAGESTREAMIO_FILEEXISTS,
-                                     "Error creating GPU SHM buffer on an existing file");
+                                     (char*)"Error creating GPU SHM buffer on an existing file");
             return IMAGESTREAMIO_FILEEXISTS;
         }
 
@@ -874,7 +767,7 @@ errno_t ImageStreamIO_createIm_gpu(
         if (SM_fd == -1)
         {
             ImageStreamIO_printERROR(IMAGESTREAMIO_FILEOPEN,
-                                     "Error opening file for writing");
+                                     (char*)"Error opening file for writing");
             return IMAGESTREAMIO_FILEOPEN;
         }
 
@@ -887,7 +780,7 @@ errno_t ImageStreamIO_createIm_gpu(
         {
             close(SM_fd);
             ImageStreamIO_printERROR(IMAGESTREAMIO_FILESEEK,
-                                     "Error calling lseek() to 'stretch' the file");
+                                     (char*)"Error calling lseek() to 'stretch' the file");
             return IMAGESTREAMIO_FILESEEK;
         }
 
@@ -896,7 +789,7 @@ errno_t ImageStreamIO_createIm_gpu(
         {
             close(SM_fd);
             ImageStreamIO_printERROR(IMAGESTREAMIO_FILEWRITE,
-                                     "Error writing last byte of the file");
+                                     (char*)"Error writing last byte of the file");
             return IMAGESTREAMIO_FILEWRITE;
         }
 
@@ -905,7 +798,7 @@ errno_t ImageStreamIO_createIm_gpu(
         if (map == MAP_FAILED)
         {
             close(SM_fd);
-            ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, "Error mmapping the file");
+            ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, (char*)"Error mmapping the file");
             return IMAGESTREAMIO_MMAP;
         }
 
@@ -922,7 +815,7 @@ errno_t ImageStreamIO_createIm_gpu(
             ret = fstat(SM_fd, &file_stat);
             if (ret < 0)
             {
-                ImageStreamIO_printERROR(IMAGESTREAMIO_INODE, "Error getting inode");
+                ImageStreamIO_printERROR(IMAGESTREAMIO_INODE, (char*)"Error getting inode");
                 return IMAGESTREAMIO_INODE;
             }
             image->md->inode =
@@ -1052,7 +945,7 @@ errno_t ImageStreamIO_createIm_gpu(
     image->md->naxis = naxis;
     strncpy(image->name, name, STRINGMAXLEN_IMAGE_NAME); // local name
     strncpy(image->md->name, name, STRINGMAXLEN_IMAGE_NAME);
-    //Ensure image and image metadata names are null-terminated
+    // Ensure image and image metadata names are null-terminated
     image->name[STRINGMAXLEN_IMAGE_NAME-1] =
     image->md->name[STRINGMAXLEN_IMAGE_NAME-1] = '\0';
     for (long i = 0; i < naxis; i++)
@@ -1135,16 +1028,20 @@ errno_t ImageStreamIO_destroyIm(
 {
     if(image->used == 1)
     {
-        // Get shm directory name (only on first call to this function)
-        for (int s=0; s<image->md->sem; ++s)
+        if (image->semptr)
         {
-            sem_destroy(image->semptr[s]);
-        }
-        if (image->semptr != NULL)
-        {
+            for (int s=0; s<image->md->sem; ++s)
+            {
+                sem_destroy(image->semptr[s]);
+            }
             free(image->semptr);
+            image->semptr = NULL;
         }
-        if (image->semlog != NULL) { sem_destroy(image->semlog); }
+        if (image->semlog)
+        {
+            sem_destroy(image->semlog);
+            image->semlog = NULL;
+        }
 
         if (image->memsize > 0)
         {
@@ -1206,14 +1103,14 @@ void *ImageStreamIO_get_image_d_ptr(
                                              cudaIpcMemLazyEnablePeerAccess));
 #else
         ImageStreamIO_printERROR(IMAGESTREAMIO_NOTIMPL,
-                                 "Error calling ImageStreamIO_get_image_d_ptr(), CACAO needs to be "
+                                 (char*)"Error calling ImageStreamIO_get_image_d_ptr(), CACAO needs to be "
                                  "compiled with -DUSE_CUDA=ON"); ///\todo should this return a NULL?
 #endif
     }
     else
     {
         ImageStreamIO_printERROR(IMAGESTREAMIO_NOTIMPL,
-                                 "Error calling ImageStreamIO_get_image_d_ptr(), wrong location"); ///\todo should this return a NULL?
+                                 (char*)"Error calling ImageStreamIO_get_image_d_ptr(), wrong location"); ///\todo should this return a NULL?
     }
     return d_ptr;
 }
@@ -1242,8 +1139,8 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
     if (SM_fd == -1)
     {
         image->used = 0;
-        char wmsg[200];
-        snprintf(wmsg, 200, "Cannot open shm file \"%s\"\n", SM_fname);
+        char wmsg[250];
+        snprintf(wmsg, sizeof wmsg, "Cannot open shm file \"%s\"\n", SM_fname);
         ImageStreamIO_printWARNING(wmsg);
         return IMAGESTREAMIO_FILEOPEN;
     }
@@ -1264,7 +1161,7 @@ errno_t ImageStreamIO_read_sharedmem_image_toIMAGE(
     if (map_root == MAP_FAILED)
     {
         close(SM_fd);
-        ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, "Error mmapping the file");
+        ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, (char*)"Error mmapping the file");
         return IMAGESTREAMIO_MMAP;
     }
 
@@ -1432,7 +1329,7 @@ errno_t ImageStreamIO_closeIm(
 
     if (munmap(image->md, image->memsize) != 0)
     {
-        ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, "error unmapping memory");
+        ImageStreamIO_printERROR(IMAGESTREAMIO_MMAP, (char*)"error unmapping memory");
         return IMAGESTREAMIO_MMAP;
     }
 
@@ -1828,8 +1725,8 @@ long ImageStreamIO_UpdateIm(
             }
             // destination pointer
             void *destptr;
-            destptr = image->CBimdata +
-                      image->md->imdatamemsize * CBindexWrite;
+            destptr = ((uint8_t*)image->CBimdata) +
+                      (image->md->imdatamemsize * CBindexWrite);
 
             memcpy(destptr, image->array.raw,
                    image->md->imdatamemsize);

--- a/ImageStreamIO.h
+++ b/ImageStreamIO.h
@@ -316,20 +316,6 @@ errno_t ImageStreamIO_closeIm(IMAGE
 /* =============================================================================================== */
 
 
-/** @brief Destroy shmim semaphores
- *
- * ## Purpose
- *
- * Destroy semaphore of a shmim
- *
- * ## Arguments
- *
- * @param[in]
- * image	IMAGE*
- * 			pointer to shmim
- */
-
-
 /** @brief Post all shmim semaphores
  *
  * ## Purpose

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,6 +4,7 @@ find_package(GTest REQUIRED)
 
 add_executable(ImageStreamIOTest
 ImageStreamIO_unitTest.cpp
+    ImageStreamIO_subTest_Operations.cpp
 )
 
 target_link_libraries(ImageStreamIOTest

--- a/tests/ImageStreamIO_unitTest.cpp
+++ b/tests/ImageStreamIO_unitTest.cpp
@@ -1,6 +1,12 @@
+#include <unistd.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+# ifdef USE_CFITSIO
+#include <fitsio.h>
+#endif//USE_CFITSIO
 #include "ImageStreamIO.h"
+#include "ImageStreamIO_subTest_Operations.hpp"
 #include "gtest/gtest.h"
-#include <limits.h>
 
 /* A prefix to all names indicating ImageStreamIO Unit Tests */
 #define SHM_NAME_PREFIX    "__ISIOUTs__"
@@ -18,6 +24,669 @@ namespace {
   int8_t cpuLocn = -1;   // Location of -1 => CPU-based shmim
   int8_t gpuLocn =  0;   // Location of  0 => Pretend GPU-based shmim
   int8_t badLocn = -2;   // Location of -2 => bad location
+
+////////////////////////////////////////////////////////////////////////
+// ImageStreamIO utilities
+// - Finding the address of the start of data of interest
+//    - SlicesAndIndices
+//    - NonCircularReadBufferAddresses
+//    - CircularReadBufferAddresses
+//    - NonCircularWroteBufferAddresses
+//    - CircularWroteBufferAddresses
+//    - NonCircularWriteBufferAddresses
+//    - CircularWriteBufferAddresses
+// - Building the shmim filename
+//    - FilenameFailure
+//    - FilenameSuccess
+// - Data type information (convert to size, name, CFITSIO type, etc.)
+//    - Typesize
+//    - Typename
+//    - Typename_7
+//    - TypenameShort
+//    - Checktype
+//    - Floattype
+//    - FITSIOdatatype
+//    - FITSIObitpix
+////////////////////////////////////////////////////////////////////////
+TEST(ImageStreamIOUtilities, SlicesAndIndices) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+
+  // - Assume last-written slice was slice 5
+  md.cnt1 = 5;
+
+  // - 1 axis:  md.size[2] and .cnt1 are ignored; number of slices is 1
+  md.imagetype &= ~CIRCULAR_BUFFER;
+  md.naxis = 1;
+  EXPECT_EQ(1, ImageStreamIO_nbSlices(&image));
+  EXPECT_EQ(0, ImageStreamIO_readLastWroteIndex(&image));
+  EXPECT_EQ(0, ImageStreamIO_writeIndex(&image));
+
+  // - 2 axes:  md.size[2] and .cnt1 are ignored; number of slices is 1
+  md.naxis = 2;
+  EXPECT_EQ(1, ImageStreamIO_nbSlices(&image));
+  EXPECT_EQ(0, ImageStreamIO_readLastWroteIndex(&image));
+  EXPECT_EQ(0, ImageStreamIO_writeIndex(&image));
+
+  // - 3 axes:  md.size[2] and .cnt1(5) are used in slice calculations
+  md.imagetype |= CIRCULAR_BUFFER;
+  md.naxis = 3;
+  EXPECT_EQ(30, ImageStreamIO_nbSlices(&image));
+  EXPECT_EQ(5, ImageStreamIO_readLastWroteIndex(&image));
+  EXPECT_EQ(6, ImageStreamIO_writeIndex(&image));
+
+  // - 3 axes with md.size[2]=300, and .cnt1 == 299:  299 is last slice;
+  //   299+1 = 300 is the next slice, but it rolls over to 0
+  md.cnt1 = 29;
+  EXPECT_EQ(30, ImageStreamIO_nbSlices(&image));
+  EXPECT_EQ(29, ImageStreamIO_readLastWroteIndex(&image));
+  EXPECT_EQ(0, ImageStreamIO_writeIndex(&image));
+}
+
+TEST(ImageStreamIOUtilities, NonCircularReadBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+  // - Place data buffer at end of md, configure buffer as non-circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 1;
+  md.imagetype &= ~CIRCULAR_BUFFER;
+
+  // - Result from ImageStreamIO_readBufferAt will be constant
+  p.raw = 0;
+  EXPECT_EQ(p.UI8,(uint8_t*)NULL);
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readBufferAt(&image,0,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readBufferAt(&image,29,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readBufferAt(&image,30,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+}
+
+TEST(ImageStreamIOUtilities, CircularReadBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+  uint64_t slice_size {0 };
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements, calculate slice size
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+  slice_size = md.size[0];
+  slice_size *= md.size[1];
+  slice_size *= 16;
+
+  // - Place data buffer at end of md, configure buffer as circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 3;
+  md.imagetype |= CIRCULAR_BUFFER;
+
+  // - Test at start of circular buffer
+  p.raw = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readBufferAt(&image,0,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  // - Test at end of circular buffer
+  p.raw = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readBufferAt(&image,29,&p.raw));
+  EXPECT_EQ(image.array.UI8+(29*slice_size),p.UI8);
+
+  // - Test past end of circular buffer (failure)
+  EXPECT_EQ(IMAGESTREAMIO_FAILURE
+           , ImageStreamIO_readBufferAt(&image,30,&p.raw));
+  EXPECT_EQ(p.UI8,(uint8_t*)NULL);
+}
+
+TEST(ImageStreamIOUtilities, NonCircularWroteBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+  // - Place data buffer at end of md, configure buffer as non-circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 1;
+  md.imagetype &= ~CIRCULAR_BUFFER;
+
+  // - Result from ImageStreamIO_readLastWroteBuffer will be constant
+  p.raw = 0;
+  md.cnt1 = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  md.cnt1 = 29;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  md.cnt1 = 30;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+}
+
+TEST(ImageStreamIOUtilities, CircularWroteBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+  uint64_t slice_size {0 };
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements, calculate slice size
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+  slice_size = md.size[0];
+  slice_size *= md.size[1];
+  slice_size *= 16;
+
+  // - Place data buffer at end of md, configure buffer as circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 3;
+  md.imagetype |= CIRCULAR_BUFFER;
+
+  // - Test at start of circular buffer
+  p.raw = 0;
+  md.cnt1 = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  // - Test at end of circular buffer
+  p.raw = 0;
+  md.cnt1 = 29;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8+(29*slice_size),p.UI8);
+
+  // - Test past end of circular buffer (failure)
+  p.raw = 0;
+  md.cnt1 = 30;
+  EXPECT_EQ(IMAGESTREAMIO_FAILURE
+           , ImageStreamIO_readLastWroteBuffer(&image,&p.raw));
+  EXPECT_EQ(p.UI8,(uint8_t*)NULL);
+}
+
+TEST(ImageStreamIOUtilities, NonCircularWriteBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+
+  // - Place data buffer at end of md, configure buffer as non-circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 1;
+  md.imagetype &= ~CIRCULAR_BUFFER;
+
+  // - Result from ImageStreamIO_writeBuffer will be constant
+  p.raw = 0;
+  md.cnt1 = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  md.cnt1 = 29;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  p.raw = 0;
+  md.cnt1 = 30;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+}
+
+TEST(ImageStreamIOUtilities, CircularWriteBufferAddresses) {
+
+  // Calculations related to the number of slices
+  // - Use local memory for IMAGE and IMAGE_METADATA structures
+  IMAGE image { 0 };
+  IMAGE_METADATA md { 0 };
+  uint8_t* pui8 { 0 };
+  union { void* raw; uint8_t* UI8; } p;
+  uint64_t slice_size {0 };
+
+  // - Make IMAGE metadata pointer point to METADATA structure
+  image.md = &md;
+
+  // - Put values in width and height sizes; 30 as slice count
+  // - Choose 16-byte data elements, calculate slice size
+  md.size[0] = 10;
+  md.size[1] = 20;
+  md.size[2] = 30;
+  md.datatype = _DATATYPE_COMPLEX_DOUBLE;
+  slice_size = md.size[0];
+  slice_size *= md.size[1];
+  slice_size *= 16;
+
+  // - Place data buffer at end of md, configure buffer as circular
+  image.array.UI8 = pui8 = ((uint8_t*)image.md) + (sizeof md);
+  md.naxis = 3;
+  md.imagetype |= CIRCULAR_BUFFER;
+
+  // - Test at start of circular buffer
+  p.raw = 0;
+  md.cnt1 = 0;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8+slice_size,p.UI8);
+
+  // - Test at end of circular buffer
+  p.raw = 0;
+  md.cnt1 = 29;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8,p.UI8);
+
+  // - Test past end of circular buffer; modulo prevents failure
+  p.raw = 0;
+  md.cnt1 = 30;
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           , ImageStreamIO_writeBuffer(&image,&p.raw));
+  EXPECT_EQ(image.array.UI8+slice_size,p.UI8);
+}
+
+// Duplicate ImageStreamIO search for directory to contain shmim file
+char* gtest_shmdirname()
+{
+  const char shmdir_envvar_name[] = { "MILK_SHM_DIR" };
+  static char shmdir_macro[] = { SHAREDMEMDIR };
+  static char slash_tmp[] = { "/tmp" };
+  char* pshmdirname = getenv("MILK_SHM_DIR");
+
+  // If envvar check returned a null pointer, advance to macro
+  if (!pshmdirname) { pshmdirname = shmdir_macro; }
+
+  while (pshmdirname)
+  {
+    struct stat statbuf;
+    if (!lstat(pshmdirname,&statbuf))
+    {
+      if ((statbuf.st_mode & S_IFMT) == S_IFDIR) { return pshmdirname; }
+    }
+    else
+    {
+      errno = 0;
+    }
+
+    // Advance shmdir name pointer to the next string to test
+    // - tmp => NULL (to terminate the search)
+    // - macro => /tmp
+    // - (else) envvar => macro
+    if (pshmdirname==slash_tmp)          { pshmdirname = (char*) NULL; }
+    else if (pshmdirname==shmdir_macro ) { pshmdirname = slash_tmp; }
+    else                                 { pshmdirname = shmdir_macro; }
+  }
+  return pshmdirname;
+}
+
+TEST(ImageStreamIOUtilities, FilenameFailure) {
+  char file_name[256];
+  char* pshmdirname = gtest_shmdirname();
+  const char gtest_name[] { "g" };
+
+  // Get minimum length of shmim file path (/dir/name.im.shm)
+  size_t toosmall{ (pshmdirname ? strlen(pshmdirname) : 0)
+                 + strlen("/")
+                 + strlen(gtest_name)
+                 + strlen(".im.shm")
+                 };
+
+  if(!pshmdirname)
+  {
+    GTEST_SKIP_("Skipped filename tests; no directory is available");
+  }
+
+  EXPECT_LT(toosmall,sizeof file_name);
+
+  // One character too small (inadeqquat space for terminating null)
+  EXPECT_EQ(IMAGESTREAMIO_FAILURE
+           ,ImageStreamIO_filename(file_name,toosmall,gtest_name));
+}
+
+TEST(ImageStreamIOUtilities, FilenameSuccess) {
+  char file_name[256];
+  char* pfile_name{0};
+  char* pshmdirname = gtest_shmdirname();
+  const char gtest_name[] { "g" };
+
+  // Get minimum length of shmim file path (/dir/name.im.shm)
+  size_t toosmall{ (pshmdirname ? strlen(pshmdirname) : 0)
+                 + strlen("/")
+                 + strlen(gtest_name)
+                 + strlen(".im.shm")
+                 };
+
+  if(!pshmdirname)
+  {
+    GTEST_SKIP_("Skipped filename tests; no directory is available");
+  }
+
+  EXPECT_LT(toosmall,sizeof file_name);
+
+  // Barely enough
+  EXPECT_EQ(IMAGESTREAMIO_SUCCESS
+           ,ImageStreamIO_filename(file_name,toosmall+1,gtest_name));
+
+  EXPECT_EQ(strlen(file_name),toosmall);
+
+  pfile_name = file_name;
+
+  EXPECT_EQ(0,strncmp(pfile_name,pshmdirname,strlen(pshmdirname)));
+  pfile_name += strlen(pshmdirname);
+
+  EXPECT_EQ('/',*pfile_name);
+  ++pfile_name;
+
+  EXPECT_EQ(0,strncmp(pfile_name,gtest_name,strlen(gtest_name)));
+  pfile_name += strlen(gtest_name);
+
+  EXPECT_EQ(0,strcmp(pfile_name,".im.shm"));
+}
+
+TEST(ImageStreamIOUtilities, Typesize) {
+# ifdef UTSEE
+# undef UTSEE
+# endif
+# define UTSEE(A,B,N) \
+         EXPECT_EQ(A, ImageStreamIO_typesize(B)); \
+         EXPECT_EQ(N, ImageStreamIO_typesize(B))
+  UTSEE(SIZEOF_DATATYPE_UINT8,           _DATATYPE_UINT8,           1);
+  UTSEE(SIZEOF_DATATYPE_INT8,            _DATATYPE_INT8,            1);
+  UTSEE(SIZEOF_DATATYPE_UINT16,          _DATATYPE_UINT16,          2);
+  UTSEE(SIZEOF_DATATYPE_INT16,           _DATATYPE_INT16,           2);
+  UTSEE(SIZEOF_DATATYPE_UINT32,          _DATATYPE_UINT32,          4);
+  UTSEE(SIZEOF_DATATYPE_INT32,           _DATATYPE_INT32,           4);
+  UTSEE(SIZEOF_DATATYPE_UINT64,          _DATATYPE_UINT64,          8);
+  UTSEE(SIZEOF_DATATYPE_INT64,           _DATATYPE_INT64,           8);
+  UTSEE(SIZEOF_DATATYPE_HALF,            _DATATYPE_HALF,            2);
+  UTSEE(SIZEOF_DATATYPE_FLOAT,           _DATATYPE_FLOAT,           4);
+  UTSEE(SIZEOF_DATATYPE_DOUBLE,          _DATATYPE_DOUBLE,          8);
+  UTSEE(SIZEOF_DATATYPE_COMPLEX_FLOAT,   _DATATYPE_COMPLEX_FLOAT,   8);
+  UTSEE(SIZEOF_DATATYPE_COMPLEX_DOUBLE,  _DATATYPE_COMPLEX_DOUBLE, 16);
+  UTSEE(-1,                              _DATATYPE_UNINITIALIZED,  -1);
+  UTSEE(-1,                              255,                      -1);
+# undef UTSEE
+}
+
+TEST(ImageStreamIOUtilities, Typename) {
+# ifdef UTNEE
+# undef UTNEE
+# endif
+# define UTNEE(A,B) \
+         EXPECT_STREQ(A, ImageStreamIO_typename(B))
+  UTNEE("UINT8",   _DATATYPE_UINT8);
+  UTNEE("INT8",    _DATATYPE_INT8);
+  UTNEE("UINT16",  _DATATYPE_UINT16);
+  UTNEE("INT16",   _DATATYPE_INT16);
+  UTNEE("UINT32",  _DATATYPE_UINT32);
+  UTNEE("INT32",   _DATATYPE_INT32);
+  UTNEE("UINT64",  _DATATYPE_UINT64);
+  UTNEE("INT64",   _DATATYPE_INT64);
+  UTNEE("FLT16",   _DATATYPE_HALF);
+  UTNEE("FLT32",   _DATATYPE_FLOAT);
+  UTNEE("FLT64",   _DATATYPE_DOUBLE);
+  UTNEE("CPLX32",  _DATATYPE_COMPLEX_FLOAT);
+  UTNEE("CPLX64",  _DATATYPE_COMPLEX_DOUBLE);
+  UTNEE("unknown", _DATATYPE_UNINITIALIZED);
+  UTNEE("unknown", 255);
+# undef UTNEE
+}
+
+TEST(ImageStreamIOUtilities, Typename_7) {
+# ifdef UT7EE
+# undef UT7EE
+# endif
+# define UT7EE(A,B) \
+         EXPECT_STREQ(A, ImageStreamIO_typename_7(B))
+  UT7EE("UINT8  ",  _DATATYPE_UINT8);
+  UT7EE("INT8   ",  _DATATYPE_INT8);
+  UT7EE("UINT16 ",  _DATATYPE_UINT16);
+  UT7EE("INT16  ",  _DATATYPE_INT16);
+  UT7EE("UINT32 ",  _DATATYPE_UINT32);
+  UT7EE("INT32  ",  _DATATYPE_INT32);
+  UT7EE("UINT64 ",  _DATATYPE_UINT64);
+  UT7EE("INT64  ",  _DATATYPE_INT64);
+  UT7EE("FLT16  ",  _DATATYPE_HALF);
+  UT7EE("FLOAT  ",  _DATATYPE_FLOAT);
+  UT7EE("DOUBLE ",  _DATATYPE_DOUBLE);
+  UT7EE("CFLOAT ",  _DATATYPE_COMPLEX_FLOAT);
+  UT7EE("CDOUBLE",  _DATATYPE_COMPLEX_DOUBLE);
+  UT7EE("unknown",  _DATATYPE_UNINITIALIZED);
+  UT7EE("unknown",  255);
+# undef UT7EE
+}
+
+TEST(ImageStreamIOUtilities, TypenameShort) {
+# ifdef UTSEE
+# undef UTSEE
+# endif
+# define UTSEE(A,B) \
+         EXPECT_STREQ(A, ImageStreamIO_typename_short(B))
+  UTSEE(" UI8",  _DATATYPE_UINT8);
+  UTSEE("  I8",  _DATATYPE_INT8);
+  UTSEE("UI16",  _DATATYPE_UINT16);
+  UTSEE(" I16",  _DATATYPE_INT16);
+  UTSEE("UI32",  _DATATYPE_UINT32);
+  UTSEE(" I32",  _DATATYPE_INT32);
+  UTSEE("UI64",  _DATATYPE_UINT64);
+  UTSEE(" I64",  _DATATYPE_INT64);
+  UTSEE(" F16",  _DATATYPE_HALF);
+  UTSEE(" FLT",  _DATATYPE_FLOAT);
+  UTSEE(" DBL",  _DATATYPE_DOUBLE);
+  UTSEE("CFLT",  _DATATYPE_COMPLEX_FLOAT);
+  UTSEE("CDBL",  _DATATYPE_COMPLEX_DOUBLE);
+  UTSEE(" ???",  _DATATYPE_UNINITIALIZED);
+  UTSEE(" ???",  255);
+# undef UTSEE
+}
+
+TEST(ImageStreamIOUtilities, Checktype) {
+# ifdef UCTEE
+# undef UCTEE
+# endif
+# define UCTEE(A,B,C) \
+         EXPECT_EQ(A, ImageStreamIO_checktype(B,0)); \
+         EXPECT_EQ(C, ImageStreamIO_checktype(B,1))
+  UCTEE( 0,  _DATATYPE_UINT8,           0);
+  UCTEE( 0,  _DATATYPE_INT8,            0);
+  UCTEE( 0,  _DATATYPE_UINT16,          0);
+  UCTEE( 0,  _DATATYPE_INT16,           0);
+  UCTEE( 0,  _DATATYPE_UINT32,          0);
+  UCTEE( 0,  _DATATYPE_INT32,           0);
+  UCTEE( 0,  _DATATYPE_UINT64,          0);
+  UCTEE( 0,  _DATATYPE_INT64,           0);
+  UCTEE( 0,  _DATATYPE_HALF,            0);
+  UCTEE( 0,  _DATATYPE_FLOAT,           0);
+  UCTEE( 0,  _DATATYPE_DOUBLE,          0);
+  UCTEE(-1,  _DATATYPE_COMPLEX_FLOAT,   0);
+  UCTEE(-1,  _DATATYPE_COMPLEX_DOUBLE,  0);
+  UCTEE(-1,  _DATATYPE_UNINITIALIZED,  -1);
+  UCTEE(-1,  255,                      -1);
+# undef UCTEE
+}
+
+TEST(ImageStreamIOUtilities, Floattype) {
+# ifdef UFTEE
+# undef UFTEE
+# endif
+# define UFTEE(A,B) \
+         EXPECT_EQ(A, ImageStreamIO_floattype(B))
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_UINT8);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_INT8);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_UINT16);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_INT16);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_UINT32);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_INT32);
+  UFTEE(_DATATYPE_DOUBLE,         _DATATYPE_UINT64);
+  UFTEE(_DATATYPE_DOUBLE,         _DATATYPE_INT64);
+  UFTEE(_DATATYPE_HALF,           _DATATYPE_HALF);
+  UFTEE(_DATATYPE_FLOAT,          _DATATYPE_FLOAT);
+  UFTEE(_DATATYPE_DOUBLE,         _DATATYPE_DOUBLE);
+  UFTEE(_DATATYPE_COMPLEX_FLOAT,  _DATATYPE_COMPLEX_FLOAT);
+  UFTEE(_DATATYPE_COMPLEX_DOUBLE, _DATATYPE_COMPLEX_DOUBLE);
+  UFTEE(-1,                       _DATATYPE_UNINITIALIZED);
+  UFTEE(-1,                       255);
+# undef UFTEE
+}
+
+TEST(ImageStreamIOUtilities, FITSIOdatatype) {
+# ifdef UFDEE
+# undef UFDEE
+# endif
+# define UFDEE(A,B) \
+         EXPECT_EQ(A, ImageStreamIO_FITSIOdatatype(B))
+# ifdef USE_CFITSIO
+  UFDEE(TBYTE,   _DATATYPE_UINT8);
+  UFDEE(TSBYTE,  _DATATYPE_INT8);
+  UFDEE(TUSHORT, _DATATYPE_UINT16);
+  UFDEE(TSHORT,  _DATATYPE_INT16);
+  UFDEE(TUINT,   _DATATYPE_UINT32);
+  UFDEE(TINT,    _DATATYPE_INT32);
+  UFDEE(TULONG,  _DATATYPE_UINT64);
+  UFDEE(TLONG,   _DATATYPE_INT64);
+  UFDEE(TFLOAT,  _DATATYPE_FLOAT);
+  UFDEE(TDOUBLE, _DATATYPE_DOUBLE);
+# else//USE_CFITSIO
+  UFDEE(-1,      _DATATYPE_UINT8);
+  UFDEE(-1,      _DATATYPE_INT8);
+  UFDEE(-1,      _DATATYPE_UINT16);
+  UFDEE(-1,      _DATATYPE_INT16);
+  UFDEE(-1,      _DATATYPE_UINT32);
+  UFDEE(-1,      _DATATYPE_INT32);
+  UFDEE(-1,      _DATATYPE_UINT64);
+  UFDEE(-1,      _DATATYPE_INT64);
+  UFDEE(-1,      _DATATYPE_FLOAT);
+  UFDEE(-1,      _DATATYPE_DOUBLE);
+# endif//USE_CFITSIO
+  UFDEE(-1,      _DATATYPE_HALF);
+  UFDEE(-1,      _DATATYPE_COMPLEX_FLOAT);
+  UFDEE(-1,      _DATATYPE_COMPLEX_DOUBLE);
+  UFDEE(-1,      _DATATYPE_UNINITIALIZED);
+  UFDEE(-1,      255);
+# undef UFDEE
+}
+
+TEST(ImageStreamIOUtilities, FITSIObitpix) {
+# ifdef UFBEE
+# undef UFBEE
+# endif
+# define UFBEE(A,B) \
+         EXPECT_EQ(A, ImageStreamIO_FITSIObitpix(B))
+# ifdef USE_CFITSIO
+  UFBEE(BYTE_IMG,      _DATATYPE_UINT8);
+  UFBEE(SBYTE_IMG,     _DATATYPE_INT8);
+  UFBEE(USHORT_IMG,    _DATATYPE_UINT16);
+  UFBEE(SHORT_IMG,     _DATATYPE_INT16);
+  UFBEE(ULONG_IMG,     _DATATYPE_UINT32);
+  UFBEE(LONG_IMG,      _DATATYPE_INT32);
+  UFBEE(ULONGLONG_IMG, _DATATYPE_UINT64);
+  UFBEE(LONGLONG_IMG,  _DATATYPE_INT64);
+  UFBEE(FLOAT_IMG,     _DATATYPE_FLOAT);
+  UFBEE(DOUBLE_IMG,    _DATATYPE_DOUBLE);
+# else//USE_CFITSIO
+  UFBEE(-1,            _DATATYPE_UINT8);
+  UFBEE(-1,            _DATATYPE_INT8);
+  UFBEE(-1,            _DATATYPE_UINT16);
+  UFBEE(-1,            _DATATYPE_INT16);
+  UFBEE(-1,            _DATATYPE_UINT32);
+  UFBEE(-1,            _DATATYPE_INT32);
+  UFBEE(-1,            _DATATYPE_UINT64);
+  UFBEE(-1,            _DATATYPE_INT64);
+  UFBEE(-1,            _DATATYPE_FLOAT);
+  UFBEE(-1,            _DATATYPE_DOUBLE);
+# endif//USE_CFITSIO
+  UFBEE(-1,            _DATATYPE_HALF);
+  UFBEE(-1,            _DATATYPE_COMPLEX_FLOAT);
+  UFBEE(-1,            _DATATYPE_COMPLEX_DOUBLE);
+  UFBEE(-1,            _DATATYPE_UNINITIALIZED);
+  UFBEE(-1,            255);
+# undef UFBEE
+}
 
 ////////////////////////////////////////////////////////////////////////
 // ImageStreamIO_creatIM_gpu - create  a shmim file 
@@ -147,6 +816,15 @@ TEST(ImageStreamIOTestLocation, InitCpuLocationFailure) {
                                       ,2, dims2, _DATATYPE_FLOAT
                                       ,gpuLocn, 1, 10, 10, MATH_DATA,0)
            );
+}
+
+// Operational test:  child process writes to shmim; parent reads
+TEST(ImageStreamIOTestOperations, OperationsTest) {
+
+  int success_count;
+  int test_count;
+  ImageStreamIO_subTest_Operations(test_count, success_count);
+  ASSERT_EQ(success_count, test_count);
 }
 
 } // namespace


### PR DESCRIPTION
- Destroy semaphores when destroying image; add better logic when cleaning up semaphores; ensure consistent line spacing before [return IMASTREAMIO_SUCCESS] statements

- Eliminate the many snprintf warnings when building ImageStreamIO, and other cleanup fixes

- Integrate new operational test into gtest

- Clean up compiler warnings; add build information to ops test module

  - ImageStreamIO.c

    - Clean up several things that may generate compiler warnings - Passing string constants to ImageStreamIO_printERROR - Performing arithmetic on pointers to void

  - tests/ImageStreamIO_subTest_Operations.cpp

    - Add comment with standalong build instructions

- Expand _build directories to ignore in .gitignore

- Update ImCreate_test.c to ImageStreamIO library:
  - Remove #include of ImageStruct.h (already included with ImageStreamIO.h)
  - Initialize parameters to ImageStreamIO_createIM within declarations
  - Make IMAGE and dimensions arrays local not malloced (nor freed)
  - Remove unused variables (x, y, s, semval)
  - Change angle step (dangle) to an exact value
  - Add missing parameter to ImageStreamIO_createIM call
  - Remove tabs; change to 4-space indents
  - Use imarray->md-> instead of imarray[0].md[0].
  - Use M_PI from math.h instead of 3.14...
  - Reverse order of nested loops for speed
  - Remove outer loop-dependent calculations from inner loop
  - Pre-calculate dy*dy
  - Allow compiler to promote integers implicitly to floats within expressions
  - Use incrementing pointer to address image elements
  - Correct cosine scaling from 0.03 to 0.003; eliminates pixel values < 0
  - Use imarray instead of &imarray[0]
  - Correct inaccurate comments; improve comments generally

- Add tests of the ImageStreamIO utilities